### PR TITLE
Update Toggl API endpoints from toggl.com to api.track.toggl.com

### DIFF
--- a/lib/toggl.js
+++ b/lib/toggl.js
@@ -43,12 +43,12 @@ const optionsToParams = options => {
 const msToHours = ms => twoDP(ms / 1000 / 60 / 60);
 
 const getReportBaseUrl = (reportType, options = {}) =>
-  `https://${TOGGL_API_KEY}:api_token@toggl.com/reports/api/v2/${reportType}/${optionsToParams(
+  `https://${TOGGL_API_KEY}:api_token@api.track.toggl.com/reports/api/v2/${reportType}/${optionsToParams(
     options,
   )}`;
 
 const getWorkspaceBaseUrl = endpoint =>
-  `https://${TOGGL_API_KEY}:api_token@toggl.com/api/v8/workspaces/${TOGGL_WORKSPACE}/${endpoint}`;
+  `https://${TOGGL_API_KEY}:api_token@api.track.toggl.com/api/v8/workspaces/${TOGGL_WORKSPACE}/${endpoint}`;
 
 const getTogglReport = (reportType, options) =>
   fetch(getReportBaseUrl(reportType, options));


### PR DESCRIPTION
Received an email from Toggl explaining that the old domain will be decommissioned and we need to update.