### PR TITLE
Feature/mlp 1761/support request types

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -32,6 +32,7 @@ const models = {
   JiraUserType: sequelize.import(__dirname + '/models/jiraUserType'),
   JiraClient: sequelize.import(__dirname + '/models/jiraClient'),
   JiraProductLabel: sequelize.import(__dirname + '/models/jiraProductLabel'),
+  JiraSupportRequestType: sequelize.import(__dirname + '/models/jiraSupportRequestType'),
 };
 
 const getModels = models => models.map(m => m.get());
@@ -381,6 +382,10 @@ const createJiraIssue = async (issue) => {
       }).then(getModel),
     ),
   );
+
+  if (issue.supportRequestType) {
+    await models.JiraSupportRequestType.create(issue.supportRequestType).catch(ignoreUniqueErrors);
+  }
 
   log.debug('JiraIssue.upsert', issue);
   models.JiraIssue.upsert(definedFieldsOnly(issue, models.JiraIssue))

--- a/db/index.js
+++ b/db/index.js
@@ -87,6 +87,10 @@ models.JiraIssue.belongsTo(models.JiraIssue, {
   as: 'parent',
 });
 
+models.JiraIssue.belongsTo(models.JiraSupportRequestType, {
+  foreignKey: 'supportRequestTypeId',
+});
+
 // jiraissue <=> jiraissuecomponents <=> jiracomponent
 models.JiraIssue.belongsToMany(models.JiraComponent, {
   through: 'jiraissuecomponents',
@@ -321,6 +325,10 @@ const createJiraIssue = async (issue) => {
     await models.JiraImpact.create(issue.impact).catch(ignoreUniqueErrors);
   }
 
+  if (issue.supportRequestType) {
+    await models.JiraSupportRequestType.create(issue.supportRequestType).catch(ignoreUniqueErrors);
+  }
+
   const drivers = await Promise.all(
     issue.drivers.map(({ id, value }) =>
       models.JiraDriver.findOrCreate({
@@ -382,10 +390,6 @@ const createJiraIssue = async (issue) => {
       }).then(getModel),
     ),
   );
-
-  if (issue.supportRequestType) {
-    await models.JiraSupportRequestType.create(issue.supportRequestType).catch(ignoreUniqueErrors);
-  }
 
   log.debug('JiraIssue.upsert', issue);
   models.JiraIssue.upsert(definedFieldsOnly(issue, models.JiraIssue))

--- a/db/models/jiraIssue.js
+++ b/db/models/jiraIssue.js
@@ -55,6 +55,10 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
+      supportRequestType: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+      },
 
       // => parentId
       // => resolutionid

--- a/db/models/jiraIssue.js
+++ b/db/models/jiraIssue.js
@@ -55,7 +55,7 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: true,
       },
-      supportRequestType: {
+      supportRequestTypeId: {
         type: DataTypes.INTEGER,
         allowNull: true,
       },

--- a/db/models/jiraSupportRequestType.js
+++ b/db/models/jiraSupportRequestType.js
@@ -1,0 +1,22 @@
+module.exports = (sequelize, DataTypes) => {
+  class JiraSupportRequestType extends sequelize.Sequelize.Model {}
+
+  JiraSupportRequestType.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+      },
+      value: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+    },
+    {
+      sequelize,
+      timestamps: false,
+      modelName: 'jirasupportrequesttype',
+    },
+  );
+  return JiraSupportRequestType;
+}

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -34,6 +34,7 @@ const parseIssue = issue => ({
   clients: issue.fields.customfield_10048 || [],
   userTypes: (issue.fields.customfield_10045 || []).map(u => pick(u, ['id', 'value'])),
   isRoadmapItem: get(issue, 'fields.customfield_10054.value') === 'Yes' ? true : false,
+  supportRequestType: get(issue, 'fields.customfield_10063', null),
   // if this is an epic, epicKey is the issue key
   epicKey: issue.fields.customfield_10014 || (issue.fields.issuetype.name === 'Epic' ? issue.key : null),
   parentKey: get(issue, 'fields.parent.key', null),

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -34,7 +34,8 @@ const parseIssue = issue => ({
   clients: issue.fields.customfield_10048 || [],
   userTypes: (issue.fields.customfield_10045 || []).map(u => pick(u, ['id', 'value'])),
   isRoadmapItem: get(issue, 'fields.customfield_10054.value') === 'Yes' ? true : false,
-  supportRequestType: get(issue, 'fields.customfield_10063', null),
+  supportRequestType: issue.fields.customfield_10063 ? pick(issue.fields.customfield_10063, ['id', 'value']) : null,
+  supportRequestTypeId: get(issue, 'fields.customfield_10063.id', null),
   // if this is an epic, epicKey is the issue key
   epicKey: issue.fields.customfield_10014 || (issue.fields.issuetype.name === 'Epic' ? issue.key : null),
   parentKey: get(issue, 'fields.parent.key', null),


### PR DESCRIPTION
# [MLP-1761]

Extract support request types into a `JiraSupportRequestType` table, add the request type ID to `jiraissues`.

I'll need a hand to deploy this as I don't think I have credentials to access the host it runs in. We'll also need to 

In terms of running a migration, I'm not finding any info on how we've done it previously. We can force sync the database to update the schemas but that'll drop all the existing data. From the interactive menu I've managed to load up the majority of the data with these steps

```
npm run start
Force-Sync DB

Sync Epics (complains about missing epic entries otherwise)

Fetch Toggl Entries (I didn't have much luck fetching entries over a time span greater than a year, so this needs to be done a couple of times)

Sync Jira Issues
```

We could look into creating migrations with sequelize cli if it's something we're going to be doing a bit more frequently.

[MLP-1761]: https://mentorloop.atlassian.net/browse/MLP-1761