### PR TITLE
Feature/mlp 2168/add toggl tags

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -23,6 +23,7 @@ const models = {
   TogglUser: sequelize.import(__dirname + '/models/togglUser'),
   TogglProject: sequelize.import(__dirname + '/models/togglProject'),
   TogglGroup: sequelize.import(__dirname + '/models/togglGroup'),
+  TogglTag: sequelize.import(__dirname + '/models/togglTag'),
   JiraIssue: sequelize.import(__dirname + '/models/jiraIssue'),
   JiraIssueType: sequelize.import(__dirname + '/models/jiraIssueType'),
   JiraProject: sequelize.import(__dirname + '/models/jiraProject'),
@@ -161,6 +162,18 @@ models.TogglUser.belongsToMany(models.TogglGroup, {
   through: 'togglgroupusers',
   foreignKey: 'userId',
   as: 'groups',
+});
+
+// togglentry <=> togglentrytags <=> toggltag
+models.TogglEntry.belongsToMany(models.TogglTag, {
+  through: 'togglentrytags',
+  foreignKey: 'entryId',
+  as: 'tags',
+});
+models.TogglTag.belongsToMany(models.TogglEntry, {
+  through: 'togglentrytags',
+  foreignKey: 'tagId',
+  as: 'entries',
 });
 
 // get toggl entries that have an issue key

--- a/db/models/togglTag.js
+++ b/db/models/togglTag.js
@@ -1,0 +1,26 @@
+module.exports = (sequelize, DataTypes) => {
+  class TogglTag extends sequelize.Sequelize.Model {}
+
+  TogglTag.init(
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+      },
+      wid: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      name: {
+        type: DataTypes.TEXT,
+        allowNull: false,
+      },
+    },
+    {
+      sequelize,
+      timestamps: false,
+      modelName: 'toggltag',
+    },
+  );
+  return TogglTag;
+};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,14 @@
+version: "3"
+
+services:
+  postgres:
+    container_name: jiggl_postgres
+    image: postgres:alpine
+    environment:
+      POSTGRES_USER: jiggluser
+      POSTGRES_PASSWORD: jigglpassword
+      POSTGRES_DB: jiggl
+    ports:
+      - "5432:5432"
+    volumes:
+      - "${HOME}/jiggl-data/:/var/lib/postgresql/data"

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const minimist = require('minimist');
 
 const {
   updateTogglGroups,
+  updateTogglTags,
 } = require('./lib/toggl');
 const {
   getIssueFromServer,
@@ -175,6 +176,7 @@ const commands = {
   'Sync Jira Issues': pullJiraIssues,
   'Sync Epics': pullJiraEpics,
   'Sync Toggl Groups': updateTogglGroups,
+  'Sync Toggl Tags': updateTogglTags,
   'Print single Jira issue': getSingleJiraIssue,
   'Update single Jira issue': updateSingleJiraIssue,
   'Update all issues from parents/epics': updatePropertiesFromParentsAndEpics,

--- a/lib/toggl.js
+++ b/lib/toggl.js
@@ -128,17 +128,36 @@ const saveReportItems = report => {
     });
     log.debug(destroyResult);
 
+    const tags = await Promise.all(
+      item.tags.map(tag =>
+        models.TogglTag.findOrCreate({
+          where: {
+            name: tag,
+          },
+        }).then(getModel),
+      ),
+    );
+
     log.debug('TogglEntry.create', item);
     await TogglEntry.create(
-      {
-        ...item,
-        issueKey: parseIssueKey(item.description),
-        hours: msToHours(item.dur),
-      },
-      {
-        fields: getModelFields(TogglEntry),
-      },
-    ).catch(ignoreUniqueErrors);
+      definedFieldsOnly(
+        {
+          ...item,
+          issueKey: parseIssueKey(item.description),
+          hours: msToHours(item.dur),
+        },
+        TogglEntry,
+      ),
+    )
+      .then(() =>
+        TogglEntry.findOne({
+          where: {
+            id: item.id,
+          },
+        }),
+      )
+      .then(savedEntry => savedEntry.setTags(tags))
+      .catch(ignoreUniqueErrors);
   });
 };
 
@@ -191,11 +210,10 @@ const updateTogglTags = async () => {
       where: {
         id: tag.id,
       },
-      defaults: definedFieldsOnly(tag, TogglTag)
-    })
-  })
-  
-}
+      defaults: definedFieldsOnly(tag, TogglTag),
+    });
+  });
+};
 
 module.exports = {
   getTogglDetailedReport,

--- a/lib/toggl.js
+++ b/lib/toggl.js
@@ -20,7 +20,7 @@ const {
 
 const { TOGGL_API_KEY, TOGGL_WORKSPACE } = config;
 
-const { TogglEntry, TogglGroup, TogglUser, TogglProject } = models;
+const { TogglEntry, TogglGroup, TogglUser, TogglProject, TogglTag } = models;
 
 const DEFAULT_PARAMS = {
   user_agent: 'jiggl',
@@ -78,6 +78,8 @@ const getGroups = () => fetch(getWorkspaceBaseUrl('groups'));
 const getUsers = () => fetch(getWorkspaceBaseUrl('users'));
 
 const getWorkspaceUsers = () => fetch(getWorkspaceBaseUrl('workspace_users'));
+
+const getWorkspaceTags = () => fetch(getWorkspaceBaseUrl('tags'));
 
 const jiraProjectRegex = /^([a-z]+)-(\d+)/i;
 
@@ -181,6 +183,20 @@ const updateTogglGroups = async () => {
   console.table(groups);
 };
 
+const updateTogglTags = async () => {
+  const tags = await getWorkspaceTags();
+
+  tags.forEach(tag => {
+    TogglTag.findOrCreate({
+      where: {
+        id: tag.id,
+      },
+      defaults: definedFieldsOnly(tag, TogglTag)
+    })
+  })
+  
+}
+
 module.exports = {
   getTogglDetailedReport,
   saveReportItems,
@@ -188,4 +204,5 @@ module.exports = {
   getUsers,
   getWorkspaceUsers,
   updateTogglGroups,
+  updateTogglTags,
 };

--- a/sync.js
+++ b/sync.js
@@ -14,6 +14,7 @@ const {
 } = require('./db');
 const {
   updateTogglGroups,
+  updateTogglTags,
 } = require('./lib/toggl');
 const {
   lastXDays,
@@ -35,6 +36,10 @@ const showtime = async () => {
   // sync the toggl groups
   log.info('syncing toggl groups');
   await updateTogglGroups();
+
+  // sync the toggl tags
+  log.info('syncing toggl tags');
+  await updateTogglTags();
 
   // pull the last week of toggl entries
   log.info('pulling toggl entries');


### PR DESCRIPTION
## [MLP-2168]

Add option to sync toggl tags to interactive menu, sync them when the sync script is run.

An entry's tag relations are stored in a through table `togglentrytags` which maps the `entryId` with the `tagId`

Also added a compose file to easily tear up/down a postgres DB.

[MLP-2168]: https://mentorloop.atlassian.net/browse/MLP-2168